### PR TITLE
Support minuteInterval on DatePickerFormItem

### DIFF
--- a/Source/Cells/DatePickerCell.swift
+++ b/Source/Cells/DatePickerCell.swift
@@ -14,6 +14,7 @@ public class DatePickerCellModel {
 	var locale: Locale? = nil // default is Locale.current, setting nil returns to default
 	var minimumDate: Date? = nil // specify min/max date range. default is nil. When min > max, the values are ignored. Ignored in countdown timer mode
 	var maximumDate: Date? = nil // default is nil
+	var minuteInterval: Int = 1
 	var date: Date = Date()
 	var expandCollapseWhenSelectingRow = true
 	var selectionStyle = UITableViewCellSelectionStyle.default
@@ -258,6 +259,7 @@ public class DatePickerExpandedCell: UITableViewCell, CellHeightProvider, WillDi
 		datePicker.datePickerMode = model.datePickerMode
 		datePicker.minimumDate = model.minimumDate
 		datePicker.maximumDate = model.maximumDate
+		datePicker.minuteInterval = model.minuteInterval
 		datePicker.locale = model.resolvedLocale
 		datePicker.date = model.date
 	}

--- a/Source/Form/DumpVisitor.swift
+++ b/Source/Form/DumpVisitor.swift
@@ -123,6 +123,7 @@ public class DumpVisitor: FormItemVisitor {
 		dict["locale"] = object.locale
 		dict["minimumDate"] = object.minimumDate
 		dict["maximumDate"] = object.maximumDate
+		dict["minuteInterval"] = object.minuteInterval
 	}
 	
 	public func visit(object: ButtonFormItem) {

--- a/Source/Form/PopulateTableView.swift
+++ b/Source/Form/PopulateTableView.swift
@@ -157,6 +157,7 @@ class PopulateTableView: FormItemVisitor {
 		model.locale = object.locale
 		model.minimumDate = object.minimumDate
 		model.maximumDate = object.maximumDate
+		model.minuteInterval = object.minuteInterval
 		model.date = object.value
 		
 		switch object.behavior {

--- a/Source/FormItems/DatePickerFormItem.swift
+++ b/Source/FormItems/DatePickerFormItem.swift
@@ -98,6 +98,7 @@ public class DatePickerFormItem: FormItem {
 	public var locale: Locale? // default is Locale.current, setting nil returns to default
 	public var minimumDate: Date? // specify min/max date range. default is nil. When min > max, the values are ignored. Ignored in countdown timer mode
 	public var maximumDate: Date? // default is nil
+	public var minuteInterval: Int = 1
 	
 	
 	public typealias ValueDidChangeBlock = (_ value: Date) -> Void


### PR DESCRIPTION
Simply allows you to specify a `minuteInterval` on `DatePickerFormItem`s, so you can do things like this:

```swift
lazy var datePicker: DatePickerFormItem = {
  let instance = DatePickerFormItem()
  instance.minuteInterval = 15
  return instance
}()
```

Works well for me, but let me know if I missed something or this doesn't fit with the library.