### PR TITLE
Label font + color customization + many fixes

### DIFF
--- a/Example/Other/OptionsViewController.swift
+++ b/Example/Other/OptionsViewController.swift
@@ -76,7 +76,7 @@ class OptionsViewController: FormViewController {
 		var selected: OptionRowModel? = nil
 		let options = optionField.options
 		if options.count > 0 {
-			let i = randomInt(0, options.count)
+			let i = Int.random(in: 0..<options.count)
 			if i < options.count {
 				selected = options[i]
 			}

--- a/Example/Other/PickerViewViewController.swift
+++ b/Example/Other/PickerViewViewController.swift
@@ -68,7 +68,7 @@ class PickerViewViewController: FormViewController {
 		var selectedRows = [Int]()
 		for rows in pickerView.pickerTitles {
 			if rows.count > 0 {
-				selectedRows.append(randomInt(0, rows.count-1))
+				selectedRows.append(Int.random(in: 0..<rows.count))
 			} else {
 				selectedRows.append(-1)
 			}

--- a/Example/Other/SegmentedControlsViewController.swift
+++ b/Example/Other/SegmentedControlsViewController.swift
@@ -79,7 +79,7 @@ class SegmentedControlsViewController: FormViewController {
 	func assignRandomValue(_ formItem: SegmentedControlFormItem) {
 		let count = formItem.items.count
 		if count > 0 {
-			formItem.selected = randomInt(0, count - 1)
+			formItem.selected = Int.random(in: 0..<count-1)
 		}
 	}
 

--- a/Example/TextView/TextViewViewController.swift
+++ b/Example/TextView/TextViewViewController.swift
@@ -62,7 +62,7 @@ class TextViewViewController: FormViewController {
 		if strings.count == 0 {
 			return ""
 		}
-		let i = randomInt(0, strings.count - 1)
+        let i = Int.random(in: 0..<strings.count)
 		return strings[i]
 	}
 

--- a/Example/Usecases/ColorPickerViewController.swift
+++ b/Example/Usecases/ColorPickerViewController.swift
@@ -87,7 +87,7 @@ class ColorPickerViewController: FormViewController {
 	}()
 
 	func assignRandomValue(_ formItem: PrecisionSliderFormItem) {
-		formItem.value = randomInt(0, 1000)
+        formItem.value = Int.random(in: 0...1000)
 	}
 
 	func randomize() {

--- a/Example/Usecases/SignUpViewController.swift
+++ b/Example/Usecases/SignUpViewController.swift
@@ -121,7 +121,7 @@ class SignUpViewController: FormViewController {
 			self?.randomize()
 		}
 		return instance
-		}()
+    }()
 
 	func pickRandom(_ strings: [String]) -> String {
 		if strings.count == 0 {

--- a/Example/Usecases/SignUpViewController.swift
+++ b/Example/Usecases/SignUpViewController.swift
@@ -127,27 +127,22 @@ class SignUpViewController: FormViewController {
 		if strings.count == 0 {
 			return ""
 		}
-		let i = randomInt(0, strings.count - 1)
+        let i = Int.random(in: 0..<strings.count)
 		return strings[i]
 	}
 
 	func pickRandomDate() -> Date {
-		let i = randomInt(20, 60)
+        let i = Int.random(in: 20...60)
 		let today = Date()
 		return offsetDate(today, years: -i)
 	}
-
-	func pickRandomBoolean() -> Bool {
-		let i = randomInt(0, 1)
-		return i == 0
-	}
-
+    
 	func randomize() {
 		userName.value = pickRandom(["john", "jane", "steve", "bill", "einstein", "newton"])
 		password.value = pickRandom(["1234", "0000", "111111", "abc", "111122223333"])
 		email.value = pickRandom(["hello@example.com", "hi@example.com", "feedback@example.com", "unsubscribe@example.com", "not-a-valid-email"])
 		birthday.value = pickRandomDate()
-		subscribeToNewsletter.value = pickRandomBoolean()
+		subscribeToNewsletter.value = Bool.random()
 	}
 
 	lazy var jsonButton: ButtonFormItem = {
@@ -159,6 +154,6 @@ class SignUpViewController: FormViewController {
 			}
 		}
 		return instance
-		}()
+    }()
 
 }

--- a/Example/Util/Random.swift
+++ b/Example/Util/Random.swift
@@ -1,7 +1,0 @@
-// MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
-
-public func randomInt(_ low: Int, _ high: Int) -> Int {
-	let diff = high - low + 1
-	return Int(arc4random_uniform(UInt32(diff))) + low
-}

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Because form code is hard to write, hard to read, hard to reason about. Has a sl
 
 ## Requirements
 
-- iOS 13
-- Xcode 11
-- Swift 5
+- iOS 9+
+- Xcode 11+
+- Swift 5.1+
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ With Swift Package Manager support in the latest Xcode, installation has never b
 
 Open your Xcode project -> `File` -> `Swift Packages` -> `Add Package Dependency...`
 
-Search for `SwiftyFORM` and specify the version you want. The lastest tagged release is usually a good idea.
+Search for `SwiftyFORM` and specify the version you want. The latest tagged release is usually a good idea.
 
 ## CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ class ChangePasswordViewController: FormViewController {
 
 # INSTALLATION
 
+## Swift Package Manager (Xcode 11+)
+
+With Swift Package Manager support in the latest Xcode, installation has never been easier.
+
+Open your Xcode project -> `File` -> `Swift Packages` -> `Add Package Dependency...`
+
+Search for `SwiftyFORM` and specify the version you want. The lastest tagged release is usually a good idea.
+
 ## CocoaPods
 
 [Link to demo project that shows a minimal SwiftyFORM app using CocoaPods](https://github.com/neoneye/SwiftyFORM-Examples).

--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@ SwiftyFORM
 
 ---
 
+<p align="center">
+
 [![Build Status](https://travis-ci.org/neoneye/SwiftyFORM.svg?branch=master)](https://travis-ci.org/neoneye/SwiftyFORM)
 [![Version](https://img.shields.io/cocoapods/v/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
 [![License](https://img.shields.io/cocoapods/l/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
 [![Platform](https://img.shields.io/cocoapods/p/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
+<a href="https://swift.org/package-manager">
+    <img src="https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
+</a>
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 
 **SwiftyFORM is an iOS framework for creating forms.**
 
 ![Screenshot of the demo app](https://github.com/neoneye/SwiftyFORM/raw/master/Documentation/light_and_dark1.png "Screenshot of the demo app")
+
+</p>
 
 Because form code is hard to write, hard to read, hard to reason about. Has a slow turn around time. Is painful to maintain.
 

--- a/README.md
+++ b/README.md
@@ -9,26 +9,32 @@ SwiftyFORM
 ---
 
 <p align="center">
-
-[![Build Status](https://travis-ci.org/neoneye/SwiftyFORM.svg?branch=master)](https://travis-ci.org/neoneye/SwiftyFORM)
-[![Version](https://img.shields.io/cocoapods/v/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
-[![Platform](https://img.shields.io/cocoapods/p/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
-<a href="https://swift.org/package-manager">
-    <img src="https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
-</a>
-<a href="https://github.com/Carthage/Carthage">
-    <img src="https://img.shields.io/badge/carthage-compatible-4BC51D.svg?style=flat" alt="Carthage" />
-</a>
-[![License](https://img.shields.io/cocoapods/l/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
-
+    <a href="https://travis-ci.org/neoneye/SwiftyFORM">
+        <img src="https://travis-ci.org/neoneye/SwiftyFORM.svg?branch=master" alt="Build Status" />
+    </a>
+    <a href="http://cocoapods.org/pods/SwiftyFORM">
+        <img src="https://img.shields.io/cocoapods/v/SwiftyFORM.svg?style=flat" alt="Version" />
+    </a>
+    <a href="http://cocoapods.org/pods/SwiftyFORM">
+        <img src="https://img.shields.io/cocoapods/p/SwiftyFORM.svg?style=flat" alt="Platform" />
+    </a>
+    <a href="https://swift.org/package-manager">
+        <img src="https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
+    </a>
+    <a href="https://github.com/Carthage/Carthage">
+        <img src="https://img.shields.io/badge/carthage-compatible-4BC51D.svg?style=flat" alt="Carthage" />
+    </a>
+    <a href="http://cocoapods.org/pods/SwiftyFORM">
+        <img src="https://img.shields.io/cocoapods/l/SwiftyFORM.svg?style=flat" alt="MIT License" />
+    </a>
 </p>
 
 <p align="center">
-**SwiftyFORM is a lightweight iOS framework for creating forms.**
+    <b>SwiftyFORM is a lightweight iOS framework for creating forms</b>
 </p>
 
 <p align="center">
-<img src="https://github.com/neoneye/SwiftyFORM/raw/master/Documentation/light_and_dark1.png" alt="Dark Mode supported" /> 
+    <img src="https://github.com/neoneye/SwiftyFORM/raw/master/Documentation/light_and_dark1.png" alt="Dark Mode supported" /> 
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -12,19 +12,25 @@ SwiftyFORM
 
 [![Build Status](https://travis-ci.org/neoneye/SwiftyFORM.svg?branch=master)](https://travis-ci.org/neoneye/SwiftyFORM)
 [![Version](https://img.shields.io/cocoapods/v/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
-[![License](https://img.shields.io/cocoapods/l/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
 [![Platform](https://img.shields.io/cocoapods/p/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
 <a href="https://swift.org/package-manager">
     <img src="https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat" alt="Swift Package Manager" />
 </a>
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-
-
-**SwiftyFORM is an iOS framework for creating forms.**
-
-![Screenshot of the demo app](https://github.com/neoneye/SwiftyFORM/raw/master/Documentation/light_and_dark1.png "Screenshot of the demo app")
+<a href="https://github.com/Carthage/Carthage">
+    <img src="https://img.shields.io/badge/carthage-compatible-4BC51D.svg?style=flat" alt="Carthage" />
+</a>
+[![License](https://img.shields.io/cocoapods/l/SwiftyFORM.svg?style=flat)](http://cocoapods.org/pods/SwiftyFORM)
 
 </p>
+
+<p align="center">
+**SwiftyFORM is a lightweight iOS framework for creating forms.**
+</p>
+
+<p align="center">
+<img src="https://github.com/neoneye/SwiftyFORM/raw/master/Documentation/light_and_dark1.png" alt="Dark Mode supported" /> 
+</p>
+
 
 Because form code is hard to write, hard to read, hard to reason about. Has a slow turn around time. Is painful to maintain.
 

--- a/Source/Cells/ButtonCell.swift
+++ b/Source/Cells/ButtonCell.swift
@@ -3,9 +3,9 @@ import UIKit
 
 public struct ButtonCellModel {
 	var title: String = ""
-    var font: UIFont = UIFont.preferredFont(forTextStyle: .body)
+    var titleFont: UIFont = UIFont.preferredFont(forTextStyle: .body)
     var textAlignment: NSTextAlignment = .center
-    var textColor: UIColor = Colors.text
+    var titleTextColor: UIColor = Colors.text
 
 	var action: () -> Void = {
 		SwiftyFormLog("action")
@@ -13,13 +13,15 @@ public struct ButtonCellModel {
 
 }
 
-public class ButtonCell: UITableViewCell, SelectRowDelegate {
+public class ButtonCell: UITableViewCell, SelectRowDelegate, AssignAppearance {
 	public let model: ButtonCellModel
 
 	public init(model: ButtonCellModel) {
 		self.model = model
 		super.init(style: .default, reuseIdentifier: nil)
 		loadWithModel(model)
+        
+        assignDefaultColors()
 	}
 
 	public required init(coder aDecoder: NSCoder) {
@@ -28,8 +30,7 @@ public class ButtonCell: UITableViewCell, SelectRowDelegate {
 
 	public func loadWithModel(_ model: ButtonCellModel) {
 		textLabel?.text = model.title
-        textLabel?.font = model.font
-        textLabel?.textColor = model.textColor
+        textLabel?.font = model.titleFont
         textLabel?.textAlignment = model.textAlignment
 	}
 
@@ -41,4 +42,13 @@ public class ButtonCell: UITableViewCell, SelectRowDelegate {
 
 		tableView.deselectRow(at: indexPath, animated: true)
 	}
+    
+    public func assignDefaultColors() {
+        textLabel?.textColor = model.titleTextColor
+    }
+    
+    public func assignTintColors() {
+        textLabel?.textColor = tintColor
+    }
+    
 }

--- a/Source/Cells/ButtonCell.swift
+++ b/Source/Cells/ButtonCell.swift
@@ -3,6 +3,9 @@ import UIKit
 
 public struct ButtonCellModel {
 	var title: String = ""
+    var font: UIFont = UIFont.preferredFont(forTextStyle: .body)
+    var textAlignment: NSTextAlignment = .center
+    var textColor: UIColor = Colors.text
 
 	var action: () -> Void = {
 		SwiftyFormLog("action")
@@ -25,7 +28,9 @@ public class ButtonCell: UITableViewCell, SelectRowDelegate {
 
 	public func loadWithModel(_ model: ButtonCellModel) {
 		textLabel?.text = model.title
-		textLabel?.textAlignment = NSTextAlignment.center
+        textLabel?.font = model.font
+        textLabel?.textColor = model.textColor
+        textLabel?.textAlignment = model.textAlignment
 	}
 
 	public func form_didSelectRow(indexPath: IndexPath, tableView: UITableView) {

--- a/Source/Cells/DatePickerCell.swift
+++ b/Source/Cells/DatePickerCell.swift
@@ -18,9 +18,9 @@ public class DatePickerCellModel {
 	var expandCollapseWhenSelectingRow = true
 	var selectionStyle = UITableViewCell.SelectionStyle.default
     var titleFont = UIFont.preferredFont(forTextStyle: .body)
-    var dateFont = UIFont.preferredFont(forTextStyle: .body)
+    var detailFont = UIFont.preferredFont(forTextStyle: .body)
     var titleTextColor = Colors.text
-    var dateTextColor = Colors.secondaryText
+    var detailTextColor = Colors.secondaryText
 
 	var valueDidChange: (Date) -> Void = { (date: Date) in
 		SwiftyFormLog("date \(date)")
@@ -39,11 +39,9 @@ public class DatePickerCellModel {
 This causes the inline date picker to expand/collapse
 */
 public class DatePickerToggleCell: UITableViewCell, SelectRowDelegate, DontCollapseWhenScrolling, AssignAppearance {
+    
 	weak var expandedCell: DatePickerExpandedCell?
 	public let model: DatePickerCellModel
-    
-    public let titleTextColor: UIColor
-    public let dateTextColor: UIColor
 
 	public init(model: DatePickerCellModel) {
 		/*
@@ -60,17 +58,12 @@ public class DatePickerToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 		assert(model.datePickerMode != .countDownTimer, "CountDownTimer is not supported")
 
 		self.model = model
-        self.titleTextColor = model.titleTextColor
-        self.dateTextColor = model.dateTextColor
 		super.init(style: .value1, reuseIdentifier: nil)
 		selectionStyle = model.selectionStyle
 		textLabel?.text = model.title
         textLabel?.font = model.titleFont
-        textLabel?.textColor = model.titleTextColor
         detailTextLabel?.font = model.dateFont
-        detailTextLabel?.textColor = model.dateTextColor
         
-    
 		updateValue()
 
 		assignDefaultColors()
@@ -227,8 +220,8 @@ public class DatePickerToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 	// MARK: AssignAppearance
 
 	public func assignDefaultColors() {
-        textLabel?.textColor = titleTextColor
-        detailTextLabel?.textColor = dateTextColor
+        textLabel?.textColor = model.titleTextColor
+        detailTextLabel?.textColor = model.detailTextColor
 	}
 
 	public func assignTintColors() {

--- a/Source/Cells/DatePickerCell.swift
+++ b/Source/Cells/DatePickerCell.swift
@@ -62,7 +62,7 @@ public class DatePickerToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 		selectionStyle = model.selectionStyle
 		textLabel?.text = model.title
         textLabel?.font = model.titleFont
-        detailTextLabel?.font = model.dateFont
+        detailTextLabel?.font = model.detailFont
         
 		updateValue()
 

--- a/Source/Cells/DatePickerCell.swift
+++ b/Source/Cells/DatePickerCell.swift
@@ -17,6 +17,10 @@ public class DatePickerCellModel {
 	var date: Date = Date()
 	var expandCollapseWhenSelectingRow = true
 	var selectionStyle = UITableViewCell.SelectionStyle.default
+    var titleFont = UIFont.preferredFont(forTextStyle: .body)
+    var dateFont = UIFont.preferredFont(forTextStyle: .body)
+    var titleTextColor = Colors.text
+    var dateTextColor = Colors.secondaryText
 
 	var valueDidChange: (Date) -> Void = { (date: Date) in
 		SwiftyFormLog("date \(date)")
@@ -37,6 +41,9 @@ This causes the inline date picker to expand/collapse
 public class DatePickerToggleCell: UITableViewCell, SelectRowDelegate, DontCollapseWhenScrolling, AssignAppearance {
 	weak var expandedCell: DatePickerExpandedCell?
 	public let model: DatePickerCellModel
+    
+    public let titleTextColor: UIColor
+    public let dateTextColor: UIColor
 
 	public init(model: DatePickerCellModel) {
 		/*
@@ -53,10 +60,17 @@ public class DatePickerToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 		assert(model.datePickerMode != .countDownTimer, "CountDownTimer is not supported")
 
 		self.model = model
+        self.titleTextColor = model.titleTextColor
+        self.dateTextColor = model.dateTextColor
 		super.init(style: .value1, reuseIdentifier: nil)
 		selectionStyle = model.selectionStyle
 		textLabel?.text = model.title
-
+        textLabel?.font = model.titleFont
+        textLabel?.textColor = model.titleTextColor
+        detailTextLabel?.font = model.dateFont
+        detailTextLabel?.textColor = model.dateTextColor
+        
+    
 		updateValue()
 
 		assignDefaultColors()
@@ -213,8 +227,8 @@ public class DatePickerToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 	// MARK: AssignAppearance
 
 	public func assignDefaultColors() {
-        textLabel?.textColor = Colors.text
-        detailTextLabel?.textColor = Colors.secondaryText
+        textLabel?.textColor = titleTextColor
+        detailTextLabel?.textColor = dateTextColor
 	}
 
 	public func assignTintColors() {

--- a/Source/Cells/OptionCell.swift
+++ b/Source/Cells/OptionCell.swift
@@ -16,6 +16,8 @@ public class OptionCell: UITableViewCell, SelectRowDelegate {
 
 	public func loadWithModel(_ model: OptionRowFormItem) {
 		textLabel?.text = model.title
+        textLabel?.font = model.font
+        textLabel?.textColor = model.textColor
 		if model.selected {
 			accessoryType = .checkmark
 		} else {

--- a/Source/Cells/OptionCell.swift
+++ b/Source/Cells/OptionCell.swift
@@ -16,8 +16,8 @@ public class OptionCell: UITableViewCell, SelectRowDelegate {
 
 	public func loadWithModel(_ model: OptionRowFormItem) {
 		textLabel?.text = model.title
-        textLabel?.font = model.font
-        textLabel?.textColor = model.textColor
+        textLabel?.font = model.titleFont
+        textLabel?.textColor = model.titleTextColor
 		if model.selected {
 			accessoryType = .checkmark
 		} else {

--- a/Source/Cells/OptionViewControllerCell.swift
+++ b/Source/Cells/OptionViewControllerCell.swift
@@ -4,6 +4,10 @@ import UIKit
 public struct OptionViewControllerCellModel {
 	var title: String = ""
 	var placeholder: String = ""
+    var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+    var titleTextColor: UIColor = Colors.text
+    var detailTextColor: UIColor = Colors.secondaryText
 	var optionField: OptionPickerFormItem?
 	var selectedOptionRow: OptionRowModel?
 
@@ -24,6 +28,10 @@ public class OptionViewControllerCell: UITableViewCell, SelectRowDelegate {
 		super.init(style: .value1, reuseIdentifier: nil)
 		accessoryType = .disclosureIndicator
 		textLabel?.text = model.title
+        textLabel?.font = model.titleFont
+        textLabel?.textColor = model.titleTextColor
+        detailTextLabel?.font = model.detailFont
+        detailTextLabel?.textColor = model.detailTextColor
 		updateValue()
 	}
 
@@ -92,4 +100,5 @@ public class OptionViewControllerCell: UITableViewCell, SelectRowDelegate {
 
 		SwiftyFormLog("did invoke")
 	}
+    
 }

--- a/Source/Cells/PickerViewCell.swift
+++ b/Source/Cells/PickerViewCell.swift
@@ -13,6 +13,8 @@ public class PickerViewCellModel {
 	var selectionStyle = UITableViewCell.SelectionStyle.default
     var titleFont: UIFont = .preferredFont(forTextStyle: .body)
     var titleTextColor: UIColor = Colors.text
+    var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+    var detailTextColor: UIColor = Colors.secondaryText
 
 	var titles = [[String]]()
 	var value = [Int]()
@@ -49,7 +51,7 @@ public class PickerViewToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 		selectionStyle = model.selectionStyle
 		textLabel?.text = model.title
         textLabel?.font = model.titleFont
-        textLabel?.textColor = model.titleTextColor
+        detailTextLabel?.font = model.detailFont
 
 		updateValue()
 
@@ -166,8 +168,8 @@ public class PickerViewToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 	// MARK: AssignAppearance
 
 	public func assignDefaultColors() {
-        textLabel?.textColor = Colors.text
-        detailTextLabel?.textColor = Colors.secondaryText
+        textLabel?.textColor = model.titleTextColor
+        detailTextLabel?.textColor = model.detailTextColor
 	}
 
 	public func assignTintColors() {

--- a/Source/Cells/PickerViewCell.swift
+++ b/Source/Cells/PickerViewCell.swift
@@ -11,6 +11,8 @@ public class PickerViewCellModel {
 	var title: String = ""
 	var expandCollapseWhenSelectingRow = true
 	var selectionStyle = UITableViewCell.SelectionStyle.default
+    var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    var titleTextColor: UIColor = Colors.text
 
 	var titles = [[String]]()
 	var value = [Int]()
@@ -46,6 +48,8 @@ public class PickerViewToggleCell: UITableViewCell, SelectRowDelegate, DontColla
 		super.init(style: .value1, reuseIdentifier: nil)
 		selectionStyle = model.selectionStyle
 		textLabel?.text = model.title
+        textLabel?.font = model.titleFont
+        textLabel?.textColor = model.titleTextColor
 
 		updateValue()
 

--- a/Source/Cells/PrecisionSliderCell.swift
+++ b/Source/Cells/PrecisionSliderCell.swift
@@ -12,6 +12,10 @@ public class PrecisionSliderCellModel {
 	var expandCollapseWhenSelectingRow = true
 	var collapseWhenResigning = false
 	var selectionStyle = UITableViewCell.SelectionStyle.default
+    var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    var titleTextColor: UIColor = Colors.text
+    var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+    var detailTextColor: UIColor = Colors.secondaryText
     var prefix = ""
     var suffix = ""
 
@@ -65,13 +69,22 @@ This causes the inline precision slider to expand/collapse
 public class PrecisionSliderToggleCell: UITableViewCell, CellHeightProvider, SelectRowDelegate, DontCollapseWhenScrolling, AssignAppearance {
 	weak var expandedCell: PrecisionSliderExpandedCell?
 	public let model: PrecisionSliderCellModel
+    
+    let titleTextColor: UIColor
+    let detailTextColor: UIColor
 
 	public init(model: PrecisionSliderCellModel) {
+        self.titleTextColor = model.titleTextColor
+        self.detailTextColor = model.detailTextColor
 		self.model = model
 		super.init(style: .value1, reuseIdentifier: nil)
 		selectionStyle = model.selectionStyle
 		clipsToBounds = true
 		textLabel?.text = model.title
+        textLabel?.font = model.titleFont
+        textLabel?.textColor = model.titleTextColor
+        detailTextLabel?.font = model.detailFont
+        detailTextLabel?.textColor = model.detailTextColor
 		reloadValueLabel()
 		assignDefaultColors()
 	}
@@ -204,8 +217,8 @@ public class PrecisionSliderToggleCell: UITableViewCell, CellHeightProvider, Sel
 	// MARK: AssignAppearance
 
 	public func assignDefaultColors() {
-        textLabel?.textColor = Colors.text
-        detailTextLabel?.textColor = Colors.secondaryText
+        textLabel?.textColor = titleTextColor
+        detailTextLabel?.textColor = detailTextColor
 	}
 
 	public func assignTintColors() {

--- a/Source/Cells/PrecisionSliderCell.swift
+++ b/Source/Cells/PrecisionSliderCell.swift
@@ -119,7 +119,7 @@ public class PrecisionSliderToggleCell: UITableViewCell, CellHeightProvider, Sel
 	}
 
 	public func form_didSelectRow(indexPath: IndexPath, tableView: UITableView) {
-		if model.expandCollapseWhenSelectingRow == false {
+		guard model.expandCollapseWhenSelectingRow else {
 			//print("cell is always expanded")
 			return
 		}
@@ -136,10 +136,7 @@ public class PrecisionSliderToggleCell: UITableViewCell, CellHeightProvider, Sel
 	// MARK: UIResponder
 
 	public override var canBecomeFirstResponder: Bool {
-		if model.expandCollapseWhenSelectingRow == false {
-			return false
-		}
-		return true
+		model.expandCollapseWhenSelectingRow
 	}
 
 	public override func becomeFirstResponder() -> Bool {

--- a/Source/Cells/StaticTextCell.swift
+++ b/Source/Cells/StaticTextCell.swift
@@ -4,15 +4,20 @@ import UIKit
 public struct StaticTextCellModel {
 	var title: String = ""
 	var value: String = ""
+    var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+    var detailTextColor: UIColor = Colors.secondaryText
+    var titleTextColor: UIColor = Colors.text
 }
 
-public class StaticTextCell: UITableViewCell {
+public class StaticTextCell: UITableViewCell, AssignAppearance {
 	public var model: StaticTextCellModel
 
 	public init(model: StaticTextCellModel) {
 		self.model = model
 		super.init(style: .value1, reuseIdentifier: nil)
 		loadWithModel(model)
+        assignDefaultColors()
 	}
 
 	public required init(coder aDecoder: NSCoder) {
@@ -23,6 +28,18 @@ public class StaticTextCell: UITableViewCell {
 		selectionStyle = .none
 		textLabel?.text = model.title
 		detailTextLabel?.text = model.value
+        textLabel?.font = model.titleFont
+        detailTextLabel?.font = model.detailFont
 	}
+    
+    public func assignDefaultColors() {
+        textLabel?.textColor = model.titleTextColor
+        detailTextLabel?.textColor = model.detailTextColor
+    }
+    
+    public func assignTintColors() {
+        textLabel?.textColor = tintColor
+        detailTextLabel?.textColor = tintColor
+    }
 
 }

--- a/Source/Cells/SwitchCell.swift
+++ b/Source/Cells/SwitchCell.swift
@@ -3,13 +3,16 @@ import UIKit
 
 public struct SwitchCellModel {
 	var title: String = ""
+    var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    var titleTextColor: UIColor = Colors.text
 
 	var valueDidChange: (Bool) -> Void = { (value: Bool) in
 		SwiftyFormLog("value \(value)")
 	}
 }
 
-public class SwitchCell: UITableViewCell {
+public class SwitchCell: UITableViewCell, AssignAppearance {
+    
 	public let model: SwitchCellModel
 	public let switchView: UISwitch
 
@@ -19,6 +22,9 @@ public class SwitchCell: UITableViewCell {
 		super.init(style: .default, reuseIdentifier: nil)
 		selectionStyle = .none
 		textLabel?.text = model.title
+        textLabel?.font = model.titleFont
+        
+        assignDefaultColors()
 
 		switchView.addTarget(self, action: #selector(SwitchCell.valueChanged), for: .valueChanged)
 		accessoryView = switchView
@@ -37,5 +43,13 @@ public class SwitchCell: UITableViewCell {
 		SwiftyFormLog("set value \(value), animated \(animated)")
 		switchView.setOn(value, animated: animated)
 	}
+    
+    public func assignDefaultColors() {
+        textLabel?.textColor = model.titleTextColor
+    }
+    
+    public func assignTintColors() {
+        textLabel?.textColor = tintColor
+    }
 
 }

--- a/Source/Cells/TextFieldCell.swift
+++ b/Source/Cells/TextFieldCell.swift
@@ -189,7 +189,10 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 		var cellHeight: CGFloat = 0
 		let veryTallCell = CGRect(x: 0, y: 0, width: cellWidth, height: CGFloat.greatestFiniteMagnitude)
 
-        var layoutMargins = self.safeAreaInsets
+        var layoutMargins = self.layoutMargins
+        if #available(iOS 11, *) {
+            layoutMargins = self.safeAreaInsets
+        }
 		layoutMargins.top = 0
 		layoutMargins.bottom = 0
 		let area = veryTallCell.inset(by: layoutMargins)

--- a/Source/Cells/TextFieldCell.swift
+++ b/Source/Cells/TextFieldCell.swift
@@ -17,18 +17,11 @@ public enum TextCellState {
 	case persistentMessage(message: String)
 }
 
-public class TextFieldFormItemCellSizes {
+public struct TextFieldFormItemCellSizes {
 	public let titleLabelFrame: CGRect
 	public let textFieldFrame: CGRect
 	public let errorLabelFrame: CGRect
 	public let cellHeight: CGFloat
-
-	public init(titleLabelFrame: CGRect, textFieldFrame: CGRect, errorLabelFrame: CGRect, cellHeight: CGFloat) {
-		self.titleLabelFrame = titleLabelFrame
-		self.textFieldFrame = textFieldFrame
-		self.errorLabelFrame = errorLabelFrame
-		self.cellHeight = cellHeight
-	}
 }
 
 public struct TextFieldFormItemCellModel {
@@ -90,7 +83,11 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 		textField.delegate = self
 
 		textField.addTarget(self, action: #selector(TextFieldFormItemCell.valueDidChange), for: UIControl.Event.editingChanged)
-
+        
+        if #available(iOS 11, *) {
+            contentView.insetsLayoutMarginsFromSafeArea = true
+        }
+        
 		contentView.addSubview(titleLabel)
 		contentView.addSubview(textField)
 		contentView.addSubview(errorLabel)
@@ -181,7 +178,7 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 	public var titleWidthMode: TitleWidthMode = .auto
 
 	public func compute() -> TextFieldFormItemCellSizes {
-		let cellWidth: CGFloat = bounds.width
+        let cellWidth: CGFloat = contentView.bounds.width
 
 		var titleLabelFrame = CGRect.zero
 		var textFieldFrame = CGRect.zero
@@ -189,10 +186,7 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 		var cellHeight: CGFloat = 0
 		let veryTallCell = CGRect(x: 0, y: 0, width: cellWidth, height: CGFloat.greatestFiniteMagnitude)
 
-        var layoutMargins = self.layoutMargins
-        if #available(iOS 11, *) {
-            layoutMargins = self.safeAreaInsets
-        }
+        var layoutMargins = contentView.layoutMargins
 		layoutMargins.top = 0
 		layoutMargins.bottom = 0
 		let area = veryTallCell.inset(by: layoutMargins)
@@ -239,7 +233,7 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 		super.layoutSubviews()
 		//SwiftyFormLog("layoutSubviews")
 		let sizes: TextFieldFormItemCellSizes = compute()
-		titleLabel.frame = sizes.titleLabelFrame
+        titleLabel.frame = sizes.titleLabelFrame
 		textField.frame = sizes.textFieldFrame
 		errorLabel.frame = sizes.errorLabelFrame
 	}

--- a/Source/Cells/TextFieldCell.swift
+++ b/Source/Cells/TextFieldCell.swift
@@ -43,6 +43,13 @@ public struct TextFieldFormItemCellModel {
 	var secureTextEntry = false
     var textAlignment: NSTextAlignment = .left
     var clearButtonMode: UITextField.ViewMode = .whileEditing
+    var titleTextColor: UIColor = Colors.text
+    var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    var detailTextColor: UIColor = Colors.secondaryText
+    var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+    var errorFont: UIFont = .preferredFont(forTextStyle: .caption2)
+    var errorTextColor: UIColor = UIColor.red
+    
 	var model: TextFieldFormItem! = nil
 
 	var valueDidChange: (String) -> Void = { (value: String) in
@@ -70,13 +77,13 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 
 		selectionStyle = .none
 
-        titleLabel.textColor = Colors.text
-		titleLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
-        textField.textColor = Colors.text
-		textField.font  = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
-		errorLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.caption2)
+        titleLabel.textColor = model.titleTextColor
+        titleLabel.font = model.titleFont
+        textField.textColor = model.detailTextColor
+        textField.font  = model.detailFont
+        errorLabel.font = model.errorFont
 
-		errorLabel.textColor = UIColor.red
+        errorLabel.textColor = model.errorTextColor
 		errorLabel.numberOfLines = 0
 
 		textField.configure()
@@ -164,7 +171,7 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 	public lazy var tapGestureRecognizer: UITapGestureRecognizer = {
 		let gr = UITapGestureRecognizer(target: self, action: #selector(TextFieldFormItemCell.handleTap(_:)))
 		return gr
-		}()
+    }()
 
 	public enum TitleWidthMode {
 		case auto
@@ -387,7 +394,7 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 	}
     
     public func assignDefaultColors() {
-        titleLabel.textColor = Colors.text
+        titleLabel.textColor = model.titleTextColor
     }
     
     public func assignTintColors() {

--- a/Source/Cells/TextFieldCell.swift
+++ b/Source/Cells/TextFieldCell.swift
@@ -189,7 +189,7 @@ public class TextFieldFormItemCell: UITableViewCell, AssignAppearance {
 		var cellHeight: CGFloat = 0
 		let veryTallCell = CGRect(x: 0, y: 0, width: cellWidth, height: CGFloat.greatestFiniteMagnitude)
 
-		var layoutMargins = self.layoutMargins
+        var layoutMargins = self.safeAreaInsets
 		layoutMargins.top = 0
 		layoutMargins.bottom = 0
 		let area = veryTallCell.inset(by: layoutMargins)

--- a/Source/Cells/TextViewCell.swift
+++ b/Source/Cells/TextViewCell.swift
@@ -51,6 +51,10 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 		if model.toolbarMode == .simple {
 			textView.inputAccessoryView = toolbar
 		}
+        
+        if #available(iOS 11, *) {
+            contentView.insetsLayoutMarginsFromSafeArea = true
+        }
 
 		contentView.addSubview(textView)
 		contentView.addSubview(titleLabel)
@@ -135,7 +139,7 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 	}
 
 	public func compute() -> TextViewFormItemCellSizes {
-		let cellWidth: CGFloat = bounds.width
+        let cellWidth: CGFloat = contentView.bounds.width
 
 		var titleLabelFrame = CGRect.zero
 		var placeholderLabelFrame = CGRect.zero
@@ -144,7 +148,7 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 		var maxY: CGFloat = 0
 		var veryTallCell = CGRect(x: 0, y: 0, width: cellWidth, height: CGFloat.greatestFiniteMagnitude)
 
-		var layoutMargins = self.layoutMargins
+		var layoutMargins = contentView.layoutMargins
 		layoutMargins.top = 0
 		layoutMargins.bottom = 0
 		veryTallCell = veryTallCell.inset(by: layoutMargins)
@@ -172,7 +176,7 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 			let availableSize = veryTallCell.size
 			let size = textView.sizeThatFits(availableSize)
 			(slice, remainder) = bottomRemainder.divided(atDistance: size.height, from: .minYEdge)
-			textViewFrame = CGRect(x: bounds.minX, y: slice.minY, width: bounds.width, height: slice.height)
+            textViewFrame = CGRect(x: contentView.bounds.minX, y: slice.minY, width: contentView.bounds.width, height: slice.height)
 		}
 		maxY = max(textViewFrame.maxY, maxY)
 
@@ -193,10 +197,11 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 		placeholderLabel.frame = sizes.placeholderLabelFrame
 		textView.frame = sizes.textViewFrame
 
-		var textViewInset = self.layoutMargins
+		var textViewInset = contentView.layoutMargins
 		textViewInset.top = 5
 		textViewInset.bottom = 10
 		textView.textContainerInset = textViewInset
+    
 	}
 
 	// MARK: UIResponder
@@ -235,10 +240,12 @@ extension TextViewCell: UITextViewDelegate {
 }
 
 extension TextViewCell: CellHeightProvider {
+    
 	public func form_cellHeight(indexPath: IndexPath, tableView: UITableView) -> CGFloat {
 		let sizes: TextViewFormItemCellSizes = compute()
 		let value = sizes.cellHeight
 		//SwiftyFormLog("compute height of row: \(value)")
 		return value
 	}
+    
 }

--- a/Source/Cells/TextViewCell.swift
+++ b/Source/Cells/TextViewCell.swift
@@ -13,13 +13,17 @@ public struct TextViewCellModel {
 	var title: String = ""
 	var placeholder: String = ""
 	var toolbarMode: ToolbarMode = .simple
+    var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    var titleTextColor: UIColor = Colors.text
+    var placeholderTextColor: UIColor = Colors.secondaryText
 
 	var valueDidChange: (String) -> Void = { (value: String) in
 		SwiftyFormLog("value \(value)")
 	}
 }
 
-public class TextViewCell: UITableViewCell {
+public class TextViewCell: UITableViewCell, AssignAppearance {
+    
 	public let titleLabel = UILabel()
 	public let placeholderLabel = UILabel()
 	public let textView = UITextView()
@@ -34,11 +38,11 @@ public class TextViewCell: UITableViewCell {
 		titleLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
 
 		placeholderLabel.text = model.placeholder
-		placeholderLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
-        placeholderLabel.textColor = Colors.secondaryText
+        placeholderLabel.font = model.titleFont
+        placeholderLabel.textColor = model.placeholderTextColor
 
-		textView.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
-        textView.textColor = Colors.text
+        textView.font = model.titleFont
+        textView.textColor = model.titleTextColor
 		textView.backgroundColor = UIColor.clear
 		textView.isScrollEnabled = false
 		textView.delegate = self
@@ -208,6 +212,15 @@ public class TextViewCell: UITableViewCell {
 	public override func resignFirstResponder() -> Bool {
 		textView.resignFirstResponder()
 	}
+    
+    public func assignDefaultColors() {
+        textView.textColor = model.titleTextColor
+    }
+    
+    public func assignTintColors() {
+        textView.textColor = tintColor
+    }
+    
 }
 
 extension TextViewCell: UITextViewDelegate {

--- a/Source/Cells/TextViewCell.swift
+++ b/Source/Cells/TextViewCell.swift
@@ -28,6 +28,10 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 	public let placeholderLabel = UILabel()
 	public let textView = UITextView()
 	public let model: TextViewCellModel
+    
+    /// keeps track of the last frame change, so we can reload the tableview if needed to get an accurate height for this cell
+    private var reloadIndexPath: IndexPath?
+    private var lastTextViewFrame: CGRect?
 
 	public init(model: TextViewCellModel) {
 		self.model = model
@@ -196,6 +200,16 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 		titleLabel.frame = sizes.titleLabelFrame
 		placeholderLabel.frame = sizes.placeholderLabelFrame
 		textView.frame = sizes.textViewFrame
+        
+        // if there was a rotation, reload the row again to ensure we get the correct height
+        if let priorFrame = lastTextViewFrame,
+            priorFrame.width != textView.frame.width,
+            let indexPath = reloadIndexPath {
+            form_tableView()?.reloadRows(at: [indexPath], with: .none)
+            reloadIndexPath = nil
+        }
+        
+        lastTextViewFrame = textView.frame
 
 		var textViewInset = contentView.layoutMargins
 		textViewInset.top = 5
@@ -244,6 +258,7 @@ extension TextViewCell: CellHeightProvider {
 	public func form_cellHeight(indexPath: IndexPath, tableView: UITableView) -> CGFloat {
 		let sizes: TextViewFormItemCellSizes = compute()
 		let value = sizes.cellHeight
+        reloadIndexPath = indexPath
 		//SwiftyFormLog("compute height of row: \(value)")
 		return value
 	}

--- a/Source/Cells/TextViewCell.swift
+++ b/Source/Cells/TextViewCell.swift
@@ -210,10 +210,10 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
         // if there is a mismatch between what the table thinks and what we display, reload to get accurate height
         if believedHeight != sizes.cellHeight,
             let indexPath = reloadIndexPath {
-            form_tableView()?.reloadRows(at: [indexPath], with: .none)
-            // only if it has changed make it nil
-            if textView.frame.height == believedHeight {
-                reloadIndexPath = nil
+            if believedHeight == 0 {
+                believedHeight = sizes.cellHeight
+            } else {
+                form_tableView()?.reloadRows(at: [indexPath], with: .none)
             }
         }
 
@@ -249,6 +249,7 @@ public class TextViewCell: UITableViewCell, AssignAppearance {
 }
 
 extension TextViewCell: UITextViewDelegate {
+    
 	public func textViewDidBeginEditing(_ textView: UITextView) {
 		updateToolbarButtons()
 	}
@@ -269,13 +270,5 @@ extension TextViewCell: CellHeightProvider {
 		//SwiftyFormLog("compute height of row: \(value)")
 		return value
 	}
-    
-}
-
-extension TextViewCell: WillDisplayCellDelegate {
-    
-    public func form_willDisplay(tableView: UITableView, forRowAtIndexPath indexPath: IndexPath) {
-        layoutSubviews()
-    }
     
 }

--- a/Source/Form/CustomizableLabels.swift
+++ b/Source/Form/CustomizableLabels.swift
@@ -1,0 +1,59 @@
+//
+//  File.swift
+//  
+//
+//  Created by Bradley Mackey on 15/10/2019.
+//
+
+import UIKit
+
+protocol CustomizableTitleLabel {
+    var title: String { get set }
+    var titleFont: UIFont { get set }
+    var titleTextColor: UIColor { get set }
+}
+
+typealias CustomizableLabels = CustomizableTitleLabel & CustomizableDetailLabel
+
+extension CustomizableTitleLabel {
+    
+    @discardableResult
+    public mutating func title(_ title: String) -> Self {
+        self.title = title
+        return self
+    }
+    
+    @discardableResult
+    public mutating func titleFont(_ titleFont: UIFont) -> Self {
+        self.titleFont = titleFont
+        return self
+    }
+    
+    @discardableResult
+    public mutating func titleTextColor(_ titleTextColor: UIColor) -> Self {
+        self.titleTextColor = titleTextColor
+        return self
+    }
+    
+}
+
+protocol CustomizableDetailLabel {
+    var detailFont: UIFont { get set }
+    var detailTextColor: UIColor { get set }
+}
+
+extension CustomizableDetailLabel {
+    
+    @discardableResult
+    public mutating func detailFont(_ detailFont: UIFont) -> Self {
+        self.detailFont = detailFont
+        return self
+    }
+    
+    @discardableResult
+    public mutating func detailTextColor(_ detailTextColor: UIColor) -> Self {
+        self.detailTextColor = detailTextColor
+        return self
+    }
+    
+}

--- a/Source/Form/CustomizableLabels.swift
+++ b/Source/Form/CustomizableLabels.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol CustomizableTitleLabel {
+public protocol CustomizableTitleLabel {
     var title: String { get set }
     var titleFont: UIFont { get set }
     var titleTextColor: UIColor { get set }
@@ -15,45 +15,50 @@ protocol CustomizableTitleLabel {
 
 typealias CustomizableLabels = CustomizableTitleLabel & CustomizableDetailLabel
 
-extension CustomizableTitleLabel {
+public extension CustomizableTitleLabel where Self: FormItem {
     
     @discardableResult
-    public mutating func title(_ title: String) -> Self {
-        self.title = title
-        return self
+    func title(_ title: String) -> Self {
+        var instance = self
+        instance.title = title
+        return instance
     }
     
     @discardableResult
-    public mutating func titleFont(_ titleFont: UIFont) -> Self {
-        self.titleFont = titleFont
-        return self
+    func titleFont(_ titleFont: UIFont) -> Self {
+        var instance = self
+        instance.titleFont = titleFont
+        return instance
     }
     
     @discardableResult
-    public mutating func titleTextColor(_ titleTextColor: UIColor) -> Self {
-        self.titleTextColor = titleTextColor
-        return self
+    func titleTextColor(_ titleTextColor: UIColor) -> Self {
+        var instance = self
+        instance.titleTextColor = titleTextColor
+        return instance
     }
     
 }
 
-protocol CustomizableDetailLabel {
+public protocol CustomizableDetailLabel {
     var detailFont: UIFont { get set }
     var detailTextColor: UIColor { get set }
 }
 
-extension CustomizableDetailLabel {
+public extension CustomizableDetailLabel where Self: FormItem {
     
     @discardableResult
-    public mutating func detailFont(_ detailFont: UIFont) -> Self {
-        self.detailFont = detailFont
-        return self
+    func detailFont(_ detailFont: UIFont) -> Self {
+        var instance = self
+        instance.detailFont = detailFont
+        return instance
     }
     
     @discardableResult
-    public mutating func detailTextColor(_ detailTextColor: UIColor) -> Self {
-        self.detailTextColor = detailTextColor
-        return self
+    func detailTextColor(_ detailTextColor: UIColor) -> Self {
+        var instance = self
+        instance.detailTextColor = detailTextColor
+        return instance
     }
     
 }

--- a/Source/Form/PopulateTableView.swift
+++ b/Source/Form/PopulateTableView.swift
@@ -114,8 +114,8 @@ class PopulateTableView: FormItemVisitor {
 		model.title = object.title
 		model.action = object.action
         model.textAlignment = object.textAlignment
-        model.font = object.titleFont
-        model.textColor = object.titleTextColor
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
 		let cell = ButtonCell(model: model)
 		cells.append(cell)
 		lastItemType = .item
@@ -156,8 +156,8 @@ class PopulateTableView: FormItemVisitor {
 		model.date = object.value
         model.titleFont = object.titleFont
         model.titleTextColor = object.titleTextColor
-        model.dateFont = object.detailFont
-        model.dateTextColor = object.detailTextColor
+        model.detailFont = object.detailFont
+        model.detailTextColor = object.detailTextColor
 
 		switch object.behavior {
 		case .collapsed, .expanded:
@@ -276,6 +276,10 @@ class PopulateTableView: FormItemVisitor {
 		model.collapseWhenResigning = object.collapseWhenResigning
         model.prefix = object.prefix
         model.suffix = object.suffix
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
+        model.detailTextColor = object.detailTextColor
+        model.detailFont = object.detailFont
 
 		switch object.behavior {
 		case .collapsed, .expanded:
@@ -469,6 +473,11 @@ class PopulateTableView: FormItemVisitor {
 		var model = StaticTextCellModel()
 		model.title = object.title
 		model.value = object.value
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
+        model.detailFont = object.detailFont
+        model.detailTextColor = object.detailTextColor
+        
 		let cell = StaticTextCell(model: model)
 		cells.append(cell)
 		lastItemType = .item
@@ -521,6 +530,8 @@ class PopulateTableView: FormItemVisitor {
 	func visit(object: SwitchFormItem) {
 		var model = SwitchCellModel()
 		model.title = object.title
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
 
 		weak var weakObject = object
 		model.valueDidChange = { (value: Bool) in
@@ -560,6 +571,13 @@ class PopulateTableView: FormItemVisitor {
 		model.autocapitalizationType = object.autocapitalizationType
 		model.spellCheckingType = object.spellCheckingType
 		model.secureTextEntry = object.secureTextEntry
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
+        model.detailFont = object.detailFont
+        model.detailTextColor = object.titleTextColor
+        model.errorFont = object.errorFont
+        model.errorTextColor = object.errorTextColor
+        
 		model.model = object
 		weak var weakObject = object
 		model.valueDidChange = { (value: String) in
@@ -612,6 +630,10 @@ class PopulateTableView: FormItemVisitor {
 		model.toolbarMode = self.model.toolbarMode
 		model.title = object.title
 		model.placeholder = object.placeholder
+        model.placeholderTextColor = object.placeholderTextColor
+        model.titleTextColor = object.titleTextColor
+        model.titleFont = object.titleFont
+        
 		weak var weakObject = object
 		model.valueDidChange = { (value: String) in
 			SwiftyFormLog("value \(value)")
@@ -673,6 +695,8 @@ class PopulateTableView: FormItemVisitor {
 		model.titles = object.pickerTitles
         model.titleFont = object.titleFont
         model.titleTextColor = object.titleTextColor
+        model.detailFont = object.detailFont
+        model.detailTextColor = object.detailTextColor
 		model.humanReadableValueSeparator = object.humanReadableValueSeparator
 
 		switch object.behavior {

--- a/Source/Form/PopulateTableView.swift
+++ b/Source/Form/PopulateTableView.swift
@@ -114,8 +114,8 @@ class PopulateTableView: FormItemVisitor {
 		model.title = object.title
 		model.action = object.action
         model.textAlignment = object.textAlignment
-        model.font = object.font
-        model.textColor = object.textColor
+        model.font = object.titleFont
+        model.textColor = object.titleTextColor
 		let cell = ButtonCell(model: model)
 		cells.append(cell)
 		lastItemType = .item
@@ -156,8 +156,8 @@ class PopulateTableView: FormItemVisitor {
 		model.date = object.value
         model.titleFont = object.titleFont
         model.titleTextColor = object.titleTextColor
-        model.dateFont = object.dateFont
-        model.dateTextColor = object.dateTextColor
+        model.dateFont = object.detailFont
+        model.dateTextColor = object.detailTextColor
 
 		switch object.behavior {
 		case .collapsed, .expanded:

--- a/Source/Form/PopulateTableView.swift
+++ b/Source/Form/PopulateTableView.swift
@@ -113,6 +113,9 @@ class PopulateTableView: FormItemVisitor {
 		var model = ButtonCellModel()
 		model.title = object.title
 		model.action = object.action
+        model.textAlignment = object.textAlignment
+        model.font = object.font
+        model.textColor = object.textColor
 		let cell = ButtonCell(model: model)
 		cells.append(cell)
 		lastItemType = .item
@@ -151,6 +154,10 @@ class PopulateTableView: FormItemVisitor {
 		model.maximumDate = object.maximumDate
 		model.minuteInterval = object.minuteInterval
 		model.date = object.value
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
+        model.dateFont = object.dateFont
+        model.dateTextColor = object.dateTextColor
 
 		switch object.behavior {
 		case .collapsed, .expanded:
@@ -213,6 +220,10 @@ class PopulateTableView: FormItemVisitor {
 		model.placeholder = object.placeholder
 		model.optionField = object
 		model.selectedOptionRow = object.selected
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
+        model.detailFont = object.detailFont
+        model.detailTextColor = object.detailTextColor
 
 		weak var weakObject = object
 		model.valueDidChange = { (value: OptionRowModel?) in
@@ -660,6 +671,8 @@ class PopulateTableView: FormItemVisitor {
 		model.title = object.title
 		model.value = object.value
 		model.titles = object.pickerTitles
+        model.titleFont = object.titleFont
+        model.titleTextColor = object.titleTextColor
 		model.humanReadableValueSeparator = object.humanReadableValueSeparator
 
 		switch object.behavior {

--- a/Source/FormItems/ButtonFormItem.swift
+++ b/Source/FormItems/ButtonFormItem.swift
@@ -1,5 +1,5 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
 public class ButtonFormItem: FormItem {
 	override func accept(visitor: FormItemVisitor) {
@@ -7,12 +7,31 @@ public class ButtonFormItem: FormItem {
 	}
 
 	public var title: String = ""
-
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
+    
+    @discardableResult
+    public func title(_ title: String) -> Self {
+        self.title = title
+        return self
+    }
+    
+    public var textColor: UIColor = Colors.text
+    
+    @discardableResult
+    public func textColor(_ textColor: UIFont) -> Self {
+        self.textColor = textColor
+        return self
+    }
+    
+    public var font: UIFont = UIFont.preferredFont(forTextStyle: .body)
+    
+    @discardableResult
+    public func font(_ font: UIFont) -> Self {
+        self.font = font
+        return self
+    }
+    
+    public var textAlignment: NSTextAlignment = .center
 
 	public var action: () -> Void = {}
+    
 }

--- a/Source/FormItems/ButtonFormItem.swift
+++ b/Source/FormItems/ButtonFormItem.swift
@@ -1,35 +1,18 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
 import UIKit
 
-public class ButtonFormItem: FormItem {
+public class ButtonFormItem: FormItem, CustomizableTitleLabel {
+    
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
 
 	public var title: String = ""
     
-    @discardableResult
-    public func title(_ title: String) -> Self {
-        self.title = title
-        return self
-    }
+    public var titleTextColor: UIColor = Colors.text
     
-    public var textColor: UIColor = Colors.text
-    
-    @discardableResult
-    public func textColor(_ textColor: UIFont) -> Self {
-        self.textColor = textColor
-        return self
-    }
-    
-    public var font: UIFont = UIFont.preferredFont(forTextStyle: .body)
-    
-    @discardableResult
-    public func font(_ font: UIFont) -> Self {
-        self.font = font
-        return self
-    }
-    
+    public var titleFont: UIFont = UIFont.preferredFont(forTextStyle: .body)
+
     public var textAlignment: NSTextAlignment = .center
 
 	public var action: () -> Void = {}

--- a/Source/FormItems/DatePickerFormItem.swift
+++ b/Source/FormItems/DatePickerFormItem.swift
@@ -1,5 +1,5 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
 public enum DatePickerFormItemMode {
 	case time
@@ -99,6 +99,12 @@ public class DatePickerFormItem: FormItem {
 	public var minimumDate: Date? // specify min/max date range. default is nil. When min > max, the values are ignored. Ignored in countdown timer mode
 	public var maximumDate: Date? // default is nil
 	public var minuteInterval: Int = 1
+    
+    public var titleFont = UIFont.preferredFont(forTextStyle: .body)
+    public var dateFont = UIFont.preferredFont(forTextStyle: .body)
+    
+    public var titleTextColor = Colors.text
+    public var dateTextColor = Colors.secondaryText
 
 	public typealias ValueDidChangeBlock = (_ value: Date) -> Void
 	public var valueDidChangeBlock: ValueDidChangeBlock = { (value: Date) in

--- a/Source/FormItems/DatePickerFormItem.swift
+++ b/Source/FormItems/DatePickerFormItem.swift
@@ -22,19 +22,13 @@ public enum DatePickerFormItemMode {
 
 Behind the scenes this creates a `UIDatePicker`.
 */
-public class DatePickerFormItem: FormItem {
+public class DatePickerFormItem: FormItem, CustomizableLabels {
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
 
 	public var title: String = ""
-
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
-
+    
 	/**
 	### Collapsed
 	
@@ -101,10 +95,10 @@ public class DatePickerFormItem: FormItem {
 	public var minuteInterval: Int = 1
     
     public var titleFont = UIFont.preferredFont(forTextStyle: .body)
-    public var dateFont = UIFont.preferredFont(forTextStyle: .body)
-    
     public var titleTextColor = Colors.text
-    public var dateTextColor = Colors.secondaryText
+    
+    public var detailFont = UIFont.preferredFont(forTextStyle: .body)
+    public var detailTextColor = Colors.secondaryText
 
 	public typealias ValueDidChangeBlock = (_ value: Date) -> Void
 	public var valueDidChangeBlock: ValueDidChangeBlock = { (value: Date) in

--- a/Source/FormItems/OptionPickerFormItem.swift
+++ b/Source/FormItems/OptionPickerFormItem.swift
@@ -15,7 +15,7 @@ public class OptionRowModel: CustomStringConvertible {
 	}
 }
 
-public class OptionPickerFormItem: FormItem {
+public class OptionPickerFormItem: FormItem, CustomizableLabels {
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
@@ -29,45 +29,15 @@ public class OptionPickerFormItem: FormItem {
 	}
 
 	public var title: String = ""
-
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
     
     public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
     
-    @discardableResult
-    public func titleFont(_ titleFont: UIFont) -> Self {
-        self.titleFont = titleFont
-        return self
-    }
-    
     public var titleTextColor: UIColor = Colors.text
-    
-    @discardableResult
-    public func titleTextColor(_ titleTextColor: UIColor) -> Self {
-        self.titleTextColor = titleTextColor
-        return self
-    }
     
     public var detailFont: UIFont = .preferredFont(forTextStyle: .body)
     
-    @discardableResult
-    public func detailFont(_ detailFont: UIFont) -> Self {
-        self.detailFont = detailFont
-        return self
-    }
+    public var detailTextColor: UIColor = Colors.secondaryText
     
-    public var detailTextColor: UIColor = Colors.text
-    
-    @discardableResult
-    public func detailTextColor(_ detailTextColor: UIColor) -> Self {
-        self.detailTextColor = detailTextColor
-        return self
-    }
-
 	public var options = [OptionRowModel]()
 
 	@discardableResult
@@ -121,36 +91,19 @@ public class OptionPickerFormItem: FormItem {
 	}
 }
 
-public class OptionRowFormItem: FormItem {
+public class OptionRowFormItem: FormItem, CustomizableTitleLabel {
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
 
 	public var title: String = ""
     
-    @discardableResult
-    public func title(_ title: String) -> Self {
-        self.title = title
-        return self
-    }
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
     
-    public var font: UIFont = .preferredFont(forTextStyle: .body)
-    
-    @discardableResult
-    public func font(_ font: UIFont) -> Self {
-        self.font = font
-        return self
-    }
-    
-    public var textColor: UIColor = Colors.text
-    
-    @discardableResult
-    public func textColor(_ textColor: UIColor) -> Self {
-        self.textColor = textColor
-        return self
-    }
+    public var titleTextColor: UIColor = Colors.text
 
 	public var selected: Bool = false
 
 	public var context: AnyObject?
+    
 }

--- a/Source/FormItems/OptionPickerFormItem.swift
+++ b/Source/FormItems/OptionPickerFormItem.swift
@@ -1,5 +1,5 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
 public class OptionRowModel: CustomStringConvertible {
 	public let title: String
@@ -35,6 +35,38 @@ public class OptionPickerFormItem: FormItem {
 		self.title = title
 		return self
 	}
+    
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    
+    @discardableResult
+    public func titleFont(_ titleFont: UIFont) -> Self {
+        self.titleFont = titleFont
+        return self
+    }
+    
+    public var titleTextColor: UIColor = Colors.text
+    
+    @discardableResult
+    public func titleTextColor(_ titleTextColor: UIColor) -> Self {
+        self.titleTextColor = titleTextColor
+        return self
+    }
+    
+    public var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+    
+    @discardableResult
+    public func detailFont(_ detailFont: UIFont) -> Self {
+        self.detailFont = detailFont
+        return self
+    }
+    
+    public var detailTextColor: UIColor = Colors.text
+    
+    @discardableResult
+    public func detailTextColor(_ detailTextColor: UIColor) -> Self {
+        self.detailTextColor = detailTextColor
+        return self
+    }
 
 	public var options = [OptionRowModel]()
 
@@ -95,12 +127,28 @@ public class OptionRowFormItem: FormItem {
 	}
 
 	public var title: String = ""
-
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
+    
+    @discardableResult
+    public func title(_ title: String) -> Self {
+        self.title = title
+        return self
+    }
+    
+    public var font: UIFont = .preferredFont(forTextStyle: .body)
+    
+    @discardableResult
+    public func font(_ font: UIFont) -> Self {
+        self.font = font
+        return self
+    }
+    
+    public var textColor: UIColor = Colors.text
+    
+    @discardableResult
+    public func textColor(_ textColor: UIColor) -> Self {
+        self.textColor = textColor
+        return self
+    }
 
 	public var selected: Bool = false
 

--- a/Source/FormItems/PickerViewFormItem.swift
+++ b/Source/FormItems/PickerViewFormItem.swift
@@ -8,34 +8,21 @@ import UIKit
 
 Behind the scenes this creates a `UIPickerView`.
 */
-public class PickerViewFormItem: FormItem {
+public class PickerViewFormItem: FormItem, CustomizableLabels {
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
 
 	public var title: String = ""
-
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
     
     public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
 
-    @discardableResult
-    public func titleFont(_ titleFont: UIFont) -> Self {
-        self.titleFont = titleFont
-        return self
-    }
-    
     public var titleTextColor: UIColor = Colors.text
+    
+    public var detailFont: UIFont = .preferredFont(forTextStyle: .body)
 
-    @discardableResult
-    public func titleTextColor(_ titleTextColor: UIColor) -> Self {
-        self.titleTextColor = titleTextColor
-        return self
-    }
+    public var detailTextColor: UIColor = Colors.secondaryText
+
 
 	/**
 	### Collapsed

--- a/Source/FormItems/PickerViewFormItem.swift
+++ b/Source/FormItems/PickerViewFormItem.swift
@@ -1,5 +1,5 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
 /**
 # Inline picker view
@@ -20,6 +20,22 @@ public class PickerViewFormItem: FormItem {
 		self.title = title
 		return self
 	}
+    
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+
+    @discardableResult
+    public func titleFont(_ titleFont: UIFont) -> Self {
+        self.titleFont = titleFont
+        return self
+    }
+    
+    public var titleTextColor: UIColor = Colors.text
+
+    @discardableResult
+    public func titleTextColor(_ titleTextColor: UIColor) -> Self {
+        self.titleTextColor = titleTextColor
+        return self
+    }
 
 	/**
 	### Collapsed

--- a/Source/FormItems/PrecisionSliderFormItem.swift
+++ b/Source/FormItems/PrecisionSliderFormItem.swift
@@ -1,5 +1,5 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
 /**
 # Inline precision slider
@@ -15,19 +15,22 @@ import Foundation
 Behind the scenes this creates a `PrecisionSlider`. This is not a standard Apple control.
 Please contact Simon Strandgaard if you have questions regarding it.
 */
-public class PrecisionSliderFormItem: FormItem {
+public class PrecisionSliderFormItem: FormItem, CustomizableLabels {
+    
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
 
 	public var title: String = ""
 
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
     
+    public var titleTextColor: UIColor = Colors.text
+
+    public var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+
+    public var detailTextColor: UIColor = Colors.secondaryText
+
     /**
      ## Prefix
      

--- a/Source/FormItems/StaticTextFormItem.swift
+++ b/Source/FormItems/StaticTextFormItem.swift
@@ -1,18 +1,21 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
-public class StaticTextFormItem: FormItem {
+public class StaticTextFormItem: FormItem, CustomizableLabels {
+    
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
 
 	public var title: String = ""
 
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    
+    public var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+    
+    public var titleTextColor: UIColor = Colors.text
+    
+    public var detailTextColor: UIColor = Colors.secondaryText
 
 	typealias SyncBlock = (_ value: String) -> Void
 	var syncCellWithValue: SyncBlock = { (string: String) in

--- a/Source/FormItems/SwitchFormItem.swift
+++ b/Source/FormItems/SwitchFormItem.swift
@@ -1,18 +1,17 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
-public class SwitchFormItem: FormItem {
+public class SwitchFormItem: FormItem, CustomizableTitleLabel {
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
 
 	public var title: String = ""
-
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
+    
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    
+    public var titleTextColor: UIColor = Colors.text
+	
 
 	public typealias SyncBlock = (_ value: Bool, _ animated: Bool) -> Void
 	public var syncCellWithValue: SyncBlock = { (value: Bool, animated: Bool) in

--- a/Source/FormItems/TextFieldFormItem.swift
+++ b/Source/FormItems/TextFieldFormItem.swift
@@ -1,7 +1,8 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
 import UIKit
 
-public class TextFieldFormItem: FormItem {
+public class TextFieldFormItem: FormItem, CustomizableLabels {
+    
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
@@ -88,11 +89,17 @@ public class TextFieldFormItem: FormItem {
 
 	public var title: String = ""
 
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    
+    public var titleTextColor: UIColor = Colors.text
+    
+    public var detailFont: UIFont = .preferredFont(forTextStyle: .body)
+       
+    public var detailTextColor: UIColor = Colors.secondaryText
+    
+    public var errorFont: UIFont = .preferredFont(forTextStyle: .caption2)
+       
+    public var errorTextColor: UIColor = UIColor.red
 
 	@discardableResult
 	public func password() -> Self {

--- a/Source/FormItems/TextViewFormItem.swift
+++ b/Source/FormItems/TextViewFormItem.swift
@@ -1,7 +1,7 @@
 // MIT license. Copyright (c) 2018 SwiftyFORM. All rights reserved.
-import Foundation
+import UIKit
 
-public class TextViewFormItem: FormItem {
+public class TextViewFormItem: FormItem, CustomizableTitleLabel {
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
@@ -16,11 +16,11 @@ public class TextViewFormItem: FormItem {
 
 	public var title: String = ""
 
-	@discardableResult
-	public func title(_ title: String) -> Self {
-		self.title = title
-		return self
-	}
+    public var titleFont: UIFont = .preferredFont(forTextStyle: .body)
+    
+    public var titleTextColor: UIColor = Colors.text
+    
+    public var placeholderTextColor: UIColor = Colors.secondaryText
 
 	typealias SyncBlock = (_ value: String) -> Void
 	var syncCellWithValue: SyncBlock = { (string: String) in


### PR DESCRIPTION
Just adds a bit more label customisation to the built in `FormItem`s to prevent the need for jumping out to `CustomFormItem` all the time (#19). Ideally this would be refactored to allow any property on a given form item to be customized without have all the code duplication, but this personally meets my requirements for now!

(Also fixed issues with iPhone X layout (#36) and bug where TextViewFormItem would size incorrectly)