### PR TITLE
Add 'simple mode' to PrecisionSliderFormItem

### DIFF
--- a/Source/Cells/PrecisionSliderCell.swift
+++ b/Source/Cells/PrecisionSliderCell.swift
@@ -18,6 +18,7 @@ public class PrecisionSliderCellModel {
     var detailTextColor: UIColor = Colors.secondaryText
     var prefix = ""
     var suffix = ""
+    var style = PrecisionSliderFormItem.Style.standard
 
 	public struct SliderDidChangeModel {
 		let value: Int
@@ -35,6 +36,7 @@ public class PrecisionSliderCellModel {
 		let decimalScale: Double = pow(Double(10), Double(decimalPlaces))
 		return Double(value) / decimalScale
 	}
+    
 }
 
 public struct PrecisionSliderCellFormatter {
@@ -72,10 +74,12 @@ public class PrecisionSliderToggleCell: UITableViewCell, CellHeightProvider, Sel
     
     let titleTextColor: UIColor
     let detailTextColor: UIColor
+    let style: PrecisionSliderFormItem.Style
 
 	public init(model: PrecisionSliderCellModel) {
         self.titleTextColor = model.titleTextColor
         self.detailTextColor = model.detailTextColor
+        self.style = model.style
 		self.model = model
 		super.init(style: .value1, reuseIdentifier: nil)
 		selectionStyle = model.selectionStyle
@@ -243,6 +247,9 @@ extension PrecisionSliderCellModel {
 		let instance = PrecisionSlider_InnerModel()
 		instance.originalMinimumValue = minimumValue
 		instance.originalMaximumValue = maximumValue
+        
+        // set the style
+        instance.style = style
 
 		let rangeLength = maximumValue - minimumValue
 
@@ -261,7 +268,7 @@ extension PrecisionSliderCellModel {
 		if let zoom = initialZoom {
 			instance.zoom = zoom
 		}
-
+        
 		// Determine how far zoom-out is possible
 		let maxZoomOutSliderWidth = Double(sliderWidth - Constants.maxZoomedOut_Inset)
 		if maxZoomOutSliderWidth > 10 && rangeLength > 0.001 {
@@ -272,6 +279,11 @@ extension PrecisionSliderCellModel {
 
 		// Determine how far zoom-in is possible
 		instance.maximumZoom = Float(log10(Constants.maxZoomedIn_DistanceBetweenMarks * decimalScale / markerSpacing))
+        // if simple, should be fully zoomed in
+        if style == .simple {
+            instance.zoom = instance.maximumZoom
+            instance.zoomMode = .none
+        }
 
 		// Prevent negative zoom-range
 		if instance.minimumZoom > instance.maximumZoom {
@@ -358,6 +370,7 @@ public class PrecisionSliderExpandedCell: UITableViewCell, CellHeightProvider, E
 
 		let sliderViewModel = model.sliderViewModel(sliderWidth: slider.bounds.width)
 		slider.model = sliderViewModel
+        slider.style = model.style
 		slider.layout.model = sliderViewModel
 		slider.reloadSlider()
 		slider.reloadZoomLabel()

--- a/Source/Form/PopulateTableView.swift
+++ b/Source/Form/PopulateTableView.swift
@@ -269,6 +269,7 @@ class PopulateTableView: FormItemVisitor {
 		model.decimalPlaces = object.decimalPlaces
 		model.minimumValue = object.minimumValue
 		model.maximumValue = object.maximumValue
+        model.style = object.style
 		model.value = object.value
 		model.title = object.title
 		model.initialZoom = object.initialZoom

--- a/Source/FormItems/PrecisionSliderFormItem.swift
+++ b/Source/FormItems/PrecisionSliderFormItem.swift
@@ -20,6 +20,12 @@ public class PrecisionSliderFormItem: FormItem, CustomizableLabels {
 	override func accept(visitor: FormItemVisitor) {
 		visitor.visit(object: self)
 	}
+    
+    public enum Style {
+        case standard
+        /// always fully zoomed in, shows true values on the markers
+        case simple
+    }
 
 	public var title: String = ""
 
@@ -30,6 +36,8 @@ public class PrecisionSliderFormItem: FormItem, CustomizableLabels {
     public var detailFont: UIFont = .preferredFont(forTextStyle: .body)
 
     public var detailTextColor: UIColor = Colors.secondaryText
+    
+    public var style: Style = .standard
 
     /**
      ## Prefix

--- a/Source/PrecisionSlider/PrecisionSlider.swift
+++ b/Source/PrecisionSlider/PrecisionSlider.swift
@@ -13,8 +13,14 @@ These gestures are available:
 
 */
 class PrecisionSlider: UIView, UICollectionViewDelegateFlowLayout, UICollectionViewDataSource, UIScrollViewDelegate, UIGestureRecognizerDelegate {
+    
 	var originalZoom: Float = 0
 	var originalValue: Double = 0
+    var style: PrecisionSliderFormItem.Style = .standard {
+        didSet {
+            model.style = style
+        }
+    }
 
 	var model = PrecisionSlider_InnerModel()
 
@@ -101,7 +107,7 @@ class PrecisionSlider: UIView, UICollectionViewDelegateFlowLayout, UICollectionV
     
     lazy var precisionPointView: UIView = {
         let instance = UIView()
-        instance.backgroundColor = Colors.text
+        instance.backgroundColor = Colors.text.withAlphaComponent(0.5)
         instance.isUserInteractionEnabled = false
         return instance
     }()
@@ -169,6 +175,7 @@ class PrecisionSlider: UIView, UICollectionViewDelegateFlowLayout, UICollectionV
 	}
 
 	@objc func handlePinch(_ gesture: UIPinchGestureRecognizer) {
+        guard style == .standard else { return }
 		if gesture.state == .began {
 			originalZoom = model.zoom
 			originalValue = self.value
@@ -203,6 +210,7 @@ class PrecisionSlider: UIView, UICollectionViewDelegateFlowLayout, UICollectionV
 
 	@objc func handleOneTouchDoubleTap(_ gesture: UIPinchGestureRecognizer) {
 		SwiftyFormLog("zoom in")
+        guard style == .standard else { return }
 		let originalZoom = model.zoom
 		let originalValue = self.value
 
@@ -259,6 +267,7 @@ class PrecisionSlider: UIView, UICollectionViewDelegateFlowLayout, UICollectionV
 
 	@objc func handleTwoTouchDoubleTap(_ gesture: UIPinchGestureRecognizer) {
 		SwiftyFormLog("zoom out")
+        guard style == .standard else { return }
 		let originalZoom = model.zoom
 		let originalValue = self.value
 
@@ -347,6 +356,7 @@ class PrecisionSlider: UIView, UICollectionViewDelegateFlowLayout, UICollectionV
 	}()
 
 	@objc func zoomInButtonAction() {
+        guard style == .standard else { return }
 		let originalZoom = model.zoom
 		let originalValue = self.value
 
@@ -383,6 +393,7 @@ class PrecisionSlider: UIView, UICollectionViewDelegateFlowLayout, UICollectionV
 	}()
 
 	@objc func zoomOutButtonAction() {
+        guard style == .standard else { return }
 		let originalZoom = model.zoom
 		let originalValue = self.value
 

--- a/Source/PrecisionSlider/PrecisionSlider_InnerModel.swift
+++ b/Source/PrecisionSlider/PrecisionSlider_InnerModel.swift
@@ -9,6 +9,7 @@ class PrecisionSlider_InnerModel: CustomDebugStringConvertible {
 		(originalMaximumValue - originalMinimumValue) / 2
 	}
 
+    var style: PrecisionSliderFormItem.Style = .standard
 	var minimumValue: Double = 0.0
 	var maximumValue: Double = 100.0
 
@@ -198,7 +199,13 @@ class PrecisionSlider_InnerModel: CustomDebugStringConvertible {
 		if hasPartialItemBefore {
 			index += 1
 		}
-		return zoomMode.markerText(index)
+        switch style {
+        case .simple:
+            return String(index)
+        case .standard:
+            return zoomMode.markerText(index)
+        }
+		
 	}
 
     let markMajorColor = Colors.text


### PR DESCRIPTION
Allow for PrecisionSliderFormItem to be a viable alternative to a regular UISlider, showing the real values for the markers and prevents zooming in or out (works best with smallish integer values) and fixed an issue where center marker on the slider was opaque.